### PR TITLE
Gh 1 enable travis

### DIFF
--- a/.foodcritic
+++ b/.foodcritic
@@ -1,1 +1,3 @@
+# Skip some deprecations of Chef 14
+~FC121
 ~FC122

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,15 @@
 dist: trusty
 sudo: required
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'deb https://packages.chef.io/repos/apt/stable trusty main'
-        key_url: 'https://packages.chef.io/chef.asc'
-    packages:
-      - chefdk
-
-before_script:
-  - eval "$(chef shell-init bash)"
-  - chef exec bundle install --with unit,smoke,travis
+install:
+  - bundle install --with unit,travis
 
 script:
   # Print versions
-  - chef --version
-  - cookstyle --version
-  - foodcritic --version
-  - kitchen --version
+  - bundle exec cookstyle --version
+  - bundle exec foodcritic --version
   # Run style checks
-  - chef exec cookstyle
-  - chef exec foodcritic --rule-file .foodcritic .
+  - bundle exec cookstyle
+  - bundle exec foodcritic --rule-file .foodcritic .
   # Run unit tests
-  - chef exec rspec
+  - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 dist: trusty
-sudo: required
 
 install:
   - bundle install --with unit,travis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the cookbook will be documented in this file.
 ## [2.0.0] - 2018-08-xx
 
 ### Added
+- [GH-1]: Travis configuration added. Uses Bundler to run unit tests and style checks.
 
 ### Changed
 - First public release of the cookbook
@@ -31,3 +32,5 @@ Version links
 <!---
 Issue links
 -->
+
+[GH-1]: https://github.com/radiator-software/cookbook-radiator/issues/1

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :unit do
   gem 'poise-service'
   gem 'poise-archive'
   gem 'cookstyle'
+  gem 'foodcritic'
 end
 
 group :junit do

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Radiator Cookbook
 
+[![Build Status](https://travis-ci.org/radiator-software/cookbook-radiator.svg?branch=master)](https://travis-ci.org/radiator-software/cookbook-radiator)
+[![Coverage Status](https://coveralls.io/repos/github/radiator-software/cookbook-radiator/badge.svg?branch=master)](https://coveralls.io/github/radiator-software/cookbook-radiator?branch=master)
+
 This cookbook strives to be a simple way of handling the installation of [Radiator](https://radiatorsoftware.com/products/radiator/) and it's dependencies on different platforms. Radiator is an AAA server for RADIUS, TACACS+ and Diameter from Radiator Software. Radiator is a commercial product and has a separate commercial license. You can find more information in the [License and Authors](#license-and-authors) section below.
 
 As Radiator is not available publicly you will need to have a wrapper cookbook or some other way of delivering the installation file to the server you are using this cookbook on.


### PR DESCRIPTION
Simplified the Travis config. Removed installation of ChefDK, now uses Bundler to run the style checks and unit tests.

Added badges to the README.